### PR TITLE
Fix 'overwriteExistingFiles' recursively

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function mergeDirs(f1, f2, overwriteExistingFiles) {
     file = files[_i];
     stats = fs.lstatSync("" + f1 + "/" + file);
     if (stats.isDirectory()) {
-      mergeDirs("" + f1 + "/" + file, "" + f2 + "/" + file)
+      mergeDirs("" + f1 + "/" + file, "" + f2 + "/" + file, overwriteExistingFiles)
     } else {
       if (!fs.existsSync("" + f2 + "/" + file) || overwriteExistingFiles) {
         fs.mkdirSync(("" + f2 + "/" + file).split("/").slice(0, -1).join("/"), 0x1ed, true);


### PR DESCRIPTION
Just added parameter 'overwriteExistingFiles' when you call mergeDirs inside mergeDirs to support overriding sub-directories, their files and so on...
Thank you for this script ;-).
PS : Not updated on npm, right ?