### PR TITLE
split out conflictresolvers

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import minimist from 'minimist'
 import mergeDirs, {conflictResolvers} from './index'
+import conflictResolvers from './conflictResolvers'
+
 const argv = minimist(process.argv.slice(2))
 
 const helpString = `Usage: merge-dirs source destination --[conflict resolver(overwrite|skip|ask)]`

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import minimist from 'minimist'
-import mergeDirs, {conflictResolvers} from './index'
+import mergeDirs from './index'
 import conflictResolvers from './conflictResolvers'
 
 const argv = minimist(process.argv.slice(2))

--- a/src/conflictresolvers.js
+++ b/src/conflictresolvers.js
@@ -1,0 +1,6 @@
+const conflictResolvers = {
+  ask: 'ask',
+  skip: 'skip',
+  overwrite: 'overwrite'
+}
+export default conflictResolvers

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,7 @@
 import fs from 'node-fs'
 import inquirer from 'inquirer'
 import path from 'path'
-
-export const conflictResolvers = {
-  ask: 'ask',
-  skip: 'skip',
-  overwrite: 'overwrite'
-}
+import conflictResolvers from './conflictresolvers'
 
 function copyFile (file, location) {
   fs.mkdirSync((file).split('/').slice(0, -1).join('/'), 0x1ed, true)


### PR DESCRIPTION
This leaves the `src/index.js` to have a single default export which (hopefully) means the `require('merge-dirs')` results in the single function being exported
