### PR TITLE
Add file modification before merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ npm-debug.log
 node_modules
 build
 test/c
+test/d

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ mergedirs('/folder/a', '/folder/b', 'overwrite');
 mergedirs('/folder/a', '/folder/b', 'ask');
 // copy folder/a into folder/b with conflict resolution 'skip'
 mergedirs('/folder/a', '/folder/b', 'skip');
+// copy folder/a into folder/b and prepend every file with the letter 'a'
+mergedirs('/folder/a', '/folder/b', 'skip', fileName => 'a' + fileName);
 ```
 
 mergedirs can also be used from the command line

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "bin": "dist/bin.js",
   "scripts": {
-    "clean": "rimraf test/c",
+    "clean": "rimraf test/c test/d",
     "prepublish": "babel src --out-dir dist",
     "mocha": "mocha --reporter spec --timeout 300 --require should --growl --compilers js:babel-register test/test.js",
     "test": "npm run clean && npm run mocha"

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ function fileAsk (src, dest) {
   inquirer.prompt([question], resolveConflict(src, dest))
 }
 
-export default function mergeDirs (src, dest, conflictResolver = conflictResolvers.skip) {
+export default function mergeDirs (src, dest, conflictResolver = conflictResolvers.skip, fileModification = fileName => fileName) {
   // handle false, for backward compatability
   if (conflictResolver === false) {
     conflictResolver = conflictResolvers.skip
@@ -84,7 +84,7 @@ export default function mergeDirs (src, dest, conflictResolver = conflictResolve
 
   files.forEach((file) => {
     const srcFile = '' + src + '/' + file
-    const destFile = '' + dest + '/' + file
+    const destFile = '' + dest + '/' + fileModification(file)
     const stats = fs.lstatSync(srcFile)
 
     if (stats.isDirectory()) {

--- a/test/test.js
+++ b/test/test.js
@@ -29,4 +29,14 @@ describe('merge dirs', function () {
     fs.existsSync(__dirname + '/c/world.txt').should.equal(true)
     done()
   })
+  it('should merge 2 folders and change the extension', function (done) {
+    fs.mkdirSync(__dirname + '/d')
+    mergedirs(__dirname + '/a', __dirname + '/d')
+    mergedirs(__dirname + '/b', __dirname + '/d', 'skip', (fileName) => fileName.substr(0, fileName.lastIndexOf(".")) + ".html")
+		//
+    fs.existsSync(__dirname + '/d/hello.txt').should.equal(true)
+    fs.existsSync(__dirname + '/d/hello.html').should.equal(true)
+    fs.existsSync(__dirname + '/d/world.html').should.equal(true)
+    done()
+  })
 })


### PR DESCRIPTION
For my use case, I would like to change the extension of the files that are merged using `merge-dirs`. I generalized this to a function that applies onto every filename so that users can apply modification during merging rather than before or after.